### PR TITLE
Adjust docker-compose configuration for MCP app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir uv
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@ COPY pyproject.toml uv.lock ./
 RUN uv sync --frozen --no-dev
 
 ENV PATH="/app/.venv/bin:$PATH"
+ENV PORT=8000
 
 COPY . .
 
-EXPOSE 8000
+EXPOSE $PORT
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD uvicorn main:app --host 0.0.0.0 --port $PORT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8000:8000"


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs dependencies with uv and runs the Starlette app with uvicorn
- introduce a docker-compose configuration to build the image and expose the service on port 8000
- remove the deprecated version declaration and redundant command from docker-compose.yml

## Testing
- uv run python -m unittest
- uv run python -m compileall main.py servers tools

------
https://chatgpt.com/codex/tasks/task_e_68e26ec71e848320a18770a92af2d253